### PR TITLE
Remove Deprecation Warning

### DIFF
--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -2,9 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0 OR GPL-3.0-only
 ---
 - name: Assure sudo installed
-  apt: pkg={{ item }} state=installed
-  with_items:
-    - sudo
+  apt: pkg="sudo" state=present
 
 - name: Assure groups created for all users
   group: name={{ item.group }} state=present

--- a/tasks/Photon.yml
+++ b/tasks/Photon.yml
@@ -5,9 +5,7 @@
   command: bash -c "rpm -q yum || tdnf install -y yum" creates=/usr/bin/yum
 
 - name: Assure sudo installed
-  yum: pkg={{ item }} state=installed
-  with_items:
-    - sudo
+  yum: pkg="sudo" state=present
 
 - name: Assure groups created for all users
   group: name={{ item.group }} state=present

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -4,7 +4,7 @@
 - name: Assure sudo installed
   package:
     name: "{{ item }}"
-    state: installed
+    state: present
   with_items:
     - sudo
 


### PR DESCRIPTION
```
[DEPRECATION WARNING]: State 'installed' is deprecated. Using state 'present' instead.
```

Ansible 2.9 will not support `state=installed` (I used the web interface, so I can only propose a change to one file at a time but I suppose we should change this elsewhere too.