### PR TITLE
WIP:Install docker-ce

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ services:
   - docker
 before_install:
   - sudo apt-get -qq update
-  - sudo apt-get install docker.io  # Install latest docker-ce
+  - sudo apt-get install -y docker.io  # Install latest docker-ce
 install:
   - pip install molecule
   # - pip install required driver (e.g. docker, python-vagrant, shade)

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ services:
   - docker
 before_install:
   - sudo apt-get -qq update
-  - sudo apt-get install -o Dpkg::Options::="--force-confold" --force-yes -y docker-engine
+  - sudo apt-get install docker.io  # Install latest docker-ce
 install:
   - pip install molecule
   # - pip install required driver (e.g. docker, python-vagrant, shade)


### PR DESCRIPTION
docker-engine has been deprecated.

This PR should fix build failures due to docker not being available.